### PR TITLE
docs: update documentation links to foundation hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 Core physics, dice rolling, and AI simulation engine for the Vindicta Platform.
 
+## Documentation
+
+> **📌 Important:** Architectural decisions and game logic axioms for the engine are documented in [**vindicta-foundation**](https://github.com/vindicta-platform/vindicta-foundation).
+
 ## Installation
+
 
 ```bash
 uv add vindicta-engine


### PR DESCRIPTION
This PR updates reference documentation links to point to the new centralized documentation hub in the `vindicta-foundation` repository.