### PR TITLE
fix(ci): pin GitHub Actions to commit SHAs (S7637)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   auto-merge:
-    uses: vindicta-platform/.github/.github/workflows/auto-merge-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/auto-merge-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   changelog:
-    uses: vindicta-platform/.github/.github/workflows/changelog-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/changelog-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   ci:
-    uses: vindicta-platform/.github/.github/workflows/ci-python-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/ci-python-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/codeowners-validator.yml
+++ b/.github/workflows/codeowners-validator.yml
@@ -10,6 +10,6 @@ on:
 
 jobs:
   validate:
-    uses: vindicta-platform/.github/.github/workflows/codeowners-validator-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/codeowners-validator-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: read

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   lint:
-    uses: vindicta-platform/.github/.github/workflows/commit-lint-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/commit-lint-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: read

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   coverage:
-    uses: vindicta-platform/.github/.github/workflows/coverage-report-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/coverage-report-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   audit:
-    uses: vindicta-platform/.github/.github/workflows/dependency-audit-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/dependency-audit-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update:
-    uses: vindicta-platform/.github/.github/workflows/dependency-update-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/dependency-update-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/deprecation-tracker.yml
+++ b/.github/workflows/deprecation-tracker.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   scan:
-    uses: vindicta-platform/.github/.github/workflows/deprecation-tracker-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/deprecation-tracker-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: read

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -10,6 +10,6 @@ on:
 
 jobs:
   verify:
-    uses: vindicta-platform/.github/.github/workflows/docs-build-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/docs-build-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,8 +9,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.x
       - run: pip install mkdocs-material

--- a/.github/workflows/docstring-coverage.yml
+++ b/.github/workflows/docstring-coverage.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   coverage:
-    uses: vindicta-platform/.github/.github/workflows/docstring-coverage-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/docstring-coverage-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: read

--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   check:
-    uses: vindicta-platform/.github/.github/workflows/license-header-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/license-header-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: read

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   lint:
-    uses: vindicta-platform/.github/.github/workflows/markdown-lint-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/markdown-lint-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: read

--- a/.github/workflows/migration-safety.yml
+++ b/.github/workflows/migration-safety.yml
@@ -10,6 +10,6 @@ on:
 
 jobs:
   check:
-    uses: vindicta-platform/.github/.github/workflows/migration-safety-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/migration-safety-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: read

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -10,6 +10,6 @@ on:
 
 jobs:
   monitor:
-    uses: vindicta-platform/.github/.github/workflows/package-size-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/package-size-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: read

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   guard:
-    uses: vindicta-platform/.github/.github/workflows/pr-guard-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/pr-guard-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/publish-gate.yml
+++ b/.github/workflows/publish-gate.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   gate:
-    uses: vindicta-platform/.github/.github/workflows/publish-gate-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/publish-gate-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: read

--- a/.github/workflows/readme-badges.yml
+++ b/.github/workflows/readme-badges.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   badges:
-    uses: vindicta-platform/.github/.github/workflows/readme-badges-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/readme-badges-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: write

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   draft:
-    uses: vindicta-platform/.github/.github/workflows/release-drafter-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/release-drafter-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: vindicta-platform/.github/.github/workflows/release-python-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/release-python-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/sast-scanner.yml
+++ b/.github/workflows/sast-scanner.yml
@@ -13,6 +13,6 @@ on:
 
 jobs:
   scan:
-    uses: vindicta-platform/.github/.github/workflows/sast-scanner-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/sast-scanner-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: read

--- a/.github/workflows/test-impact.yml
+++ b/.github/workflows/test-impact.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   analyze:
-    uses: vindicta-platform/.github/.github/workflows/test-impact-template.yml@main
+    uses: vindicta-platform/.github/.github/workflows/test-impact-template.yml@1216e0609ec638b935e0f4123b2f9fcc69cfe14f # main
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary

Pin all GitHub Actions dependencies to full commit SHA hashes, resolving 19 SonarCloud security hotspots (rule `S7637`).

## Problem

All workflow files referenced reusable workflows and actions using mutable references (`@main`, `@v4`, `@v5`). This creates a supply-chain risk where a compromised upstream repository could inject malicious code.

## Fix

Replaced all mutable tag/branch references with immutable full commit SHA hashes:

| Action/Workflow | Old Reference | New Reference (SHA) |
|---|---|---|
| `vindicta-platform/.github/...` | `@main` | `@1216e0609ec638b935e0f4123b2f9fcc69cfe14f` |
| `actions/checkout` | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1) |
| `actions/setup-python` | `@v5` | `@a26af69be951a213d495a4c3e4e4022e16d87065` (v5.6.0) |

Each SHA is annotated with a `# version` comment for maintainability.

### Files Changed (22)

All files in `.github/workflows/`:
`auto-merge.yml`, `changelog.yml`, `ci.yml`, `codeowners-validator.yml`, `commit-lint.yml`, `coverage-report.yml`, `dependency-audit.yml`, `dependency-update.yml`, `deprecation-tracker.yml`, `docs-build.yml`, `docs.yml`, `docstring-coverage.yml`, `license-header.yml`, `markdown-lint.yml`, `migration-safety.yml`, `package-size.yml`, `pr-guard.yml`, `publish-gate.yml`, `readme-badges.yml`, `release-drafter.yml`, `release.yml`, `sast-scanner.yml`, `test-impact.yml`

## SonarCloud References

- Rule: [S7637](https://rules.sonarsource.com/github-actions/RSPEC-7637/)
- Severity: LOW (Security Hotspot)
- **19 hotspots resolved** → Quality gate `new_security_hotspots_reviewed` should pass

## Quality Gate Impact

The `vindicta-engine` project was failing the SonarCloud quality gate **solely** due to `new_security_hotspots_reviewed = 0%`. This PR addresses the root cause by eliminating the hotspots entirely.